### PR TITLE
Add author entry in the gsoc feed

### DIFF
--- a/_pages/gsoc.xml
+++ b/_pages/gsoc.xml
@@ -20,6 +20,10 @@ author_profile: true
 					  <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
 					  <link>{{ post.url | prepend: site.url }}</link>
 					  <guid isPermaLink="true">{{ post.url | prepend: site.url }}</guid>
+            <author>
+              <name>{{ site.author.name }}</name>
+              <email>{{ site.author.email }}</email>
+            </author>
 				  </item>
 				{% endif %}
 			{% endfor %}


### PR DESCRIPTION
Missing the author information on the gsoc xml is making the feed parser to fail when grabbing your posts for the Open Astronomy page. Hopefully this fixes it!!